### PR TITLE
Fixes to layout and translation UI

### DIFF
--- a/src/main/webapp/portal/admin/account/batchcreateuseraccounts.jsp
+++ b/src/main/webapp/portal/admin/account/batchcreateuseraccounts.jsp
@@ -34,7 +34,7 @@
 <body>
 
 <div id="page">
-	<div id="pageContent">
+	<div id="pageContent" style="width:auto;">
 		<h5 style="color:#0000CC;"><a href="${contextPath}/admin"><spring:message code="returnToMainAdminPage" /></a></h5>
 		<br/>
 		<c:if test="${msg != null}">

--- a/src/main/webapp/portal/admin/account/batchcreateuseraccounts.jsp
+++ b/src/main/webapp/portal/admin/account/batchcreateuseraccounts.jsp
@@ -10,6 +10,9 @@
 	<link href="${contextPath}/<spring:theme code="stylesheet"/>" media="screen" rel="stylesheet" type="text/css" />
 	<link href="${contextPath}/<spring:theme code="teacherprojectstylesheet" />" media="screen" rel="stylesheet" type="text/css" />
 	<link href="${contextPath}/<spring:theme code="teacherhomepagestylesheet" />" media="screen" rel="stylesheet" type="text/css" />
+	<c:if test="${textDirection == 'rtl' }">
+			<link href="${contextPath}/<spring:theme code="rtlstylesheet"/>" rel="stylesheet" type="text/css" >
+	</c:if>
 	<%@ include file="../../favicon.jsp"%>
 
 	<script src="${contextPath}/<spring:theme code="generalsource" />" type="text/javascript"></script>

--- a/src/main/webapp/portal/admin/account/enabledisableuser.jsp
+++ b/src/main/webapp/portal/admin/account/enabledisableuser.jsp
@@ -10,6 +10,9 @@
 <link href="${contextPath}/<spring:theme code="stylesheet"/>" media="screen" rel="stylesheet" type="text/css" />
 <link href="${contextPath}/<spring:theme code="teacherprojectstylesheet" />" media="screen" rel="stylesheet" type="text/css" />
 <link href="${contextPath}/<spring:theme code="teacherhomepagestylesheet" />" media="screen" rel="stylesheet" type="text/css" />
+<c:if test="${textDirection == 'rtl' }">
+		<link href="${contextPath}/<spring:theme code="rtlstylesheet"/>" rel="stylesheet" type="text/css" >
+</c:if>
 <%@ include file="../../favicon.jsp"%>
 
 <script src="${contextPath}/<spring:theme code="generalsource" />" type="text/javascript"></script>

--- a/src/main/webapp/portal/admin/account/enabledisableuser.jsp
+++ b/src/main/webapp/portal/admin/account/enabledisableuser.jsp
@@ -59,7 +59,7 @@
 
 <body onload="document.getElementById('usernameToDisable').focus();">
 <div id="page">
-<div id="pageContent">
+<div id="pageContent" style="width:auto;">
 
 	<h5 style="color: #0000CC;">
 		<a href="${contextPath}/admin"><spring:message code="returnToMainAdminPage" /></a>

--- a/src/main/webapp/portal/admin/account/lookupuser.jsp
+++ b/src/main/webapp/portal/admin/account/lookupuser.jsp
@@ -37,7 +37,7 @@ function lookupFieldChanged() {
 <body onload="document.getElementById('lookupData').focus();">
 
 <div id="page">
-<div id="pageContent">
+<div id="pageContent" style="width:auto;">
 <h5 style="color:#0000CC;"><a href="${contextPath}/admin"><spring:message code="returnToMainAdminPage" /></a></h5>
 <br>
 

--- a/src/main/webapp/portal/admin/project/currentlyAuthoredProjects.jsp
+++ b/src/main/webapp/portal/admin/project/currentlyAuthoredProjects.jsp
@@ -29,6 +29,7 @@ table, tr, td {
 </style>
 </head>
 <body>
+<div id="pageWrapper">
 <%@ include file="../../headermain.jsp"%>
 <div id="page">
 <div id="pageContent" class="contentPanel">
@@ -64,6 +65,7 @@ table, tr, td {
 		</c:otherwise>
 	</c:choose>
 </div></div>
+</div>
 
 </body>
 </html>

--- a/src/main/webapp/portal/admin/project/import.jsp
+++ b/src/main/webapp/portal/admin/project/import.jsp
@@ -46,6 +46,7 @@
 	</script>
 </head>
 <body>
+<div id="pageWrapper">
 <%@ include file="../../headermain.jsp"%>
 <div id="page">
 	<div id="pageContent" class="contentPanel">
@@ -130,6 +131,7 @@ unzipped:
 			</form:form>
 		</div>
 	</div>
+</div>
 </div>
 </body>
 </html>

--- a/src/main/webapp/portal/admin/project/manageallprojects.jsp
+++ b/src/main/webapp/portal/admin/project/manageallprojects.jsp
@@ -85,6 +85,7 @@ function updateMaxTotalAssetsSize(projectId, newMaxTotalAssetsSize) {
 }
 </script>
 <body>
+<div id="pageWrapper">
 <%@ include file="../../headermain.jsp"%>
 <div id="page">
 <div id="pageContent" class="contentPanel">
@@ -157,5 +158,6 @@ function updateMaxTotalAssetsSize(projectId, newMaxTotalAssetsSize) {
 </table>
 
 </div></div>
+</div>
 </body>
 </html>

--- a/src/main/webapp/portal/admin/run/mergespreadsheets.jsp
+++ b/src/main/webapp/portal/admin/run/mergespreadsheets.jsp
@@ -24,7 +24,7 @@
 <body>
 
 <div id="page">
-    <div id="pageContent">
+    <div id="pageContent" style="width:auto;">
         <h5 style="color:#0000CC;"><a href="${contextPath}/admin"><spring:message
                 code="returnToMainAdminPage"/></a></h5>
         <br/>

--- a/src/main/webapp/portal/admin/run/replacebase64withpng.jsp
+++ b/src/main/webapp/portal/admin/run/replacebase64withpng.jsp
@@ -30,7 +30,7 @@
 <body>
 
 <div id="page">
-    <div id="pageContent">
+    <div id="pageContent" style="width:auto;">
         <h5 style="color:#0000CC;"><a href="${contextPath}/admin"><spring:message
                 code="returnToMainAdminPage"/></a></h5>
         <br/>

--- a/src/main/webapp/portal/admin/run/runswithinperiod.jsp
+++ b/src/main/webapp/portal/admin/run/runswithinperiod.jsp
@@ -25,6 +25,7 @@ th {
 </style>
 </head>
 <body>
+<div id="pageWrapper">
 <%@ include file="../../headermain.jsp"%>
 
 <div id="page">
@@ -70,6 +71,7 @@ th {
 </table>
 </div>
 
+</div>
 </div>
 </body>
 </html>

--- a/src/main/webapp/portal/include.jsp
+++ b/src/main/webapp/portal/include.jsp
@@ -34,6 +34,8 @@ Properties wiseProperties = new Properties();
 wiseProperties.load(getClass().getClassLoader().getResourceAsStream("wise.properties"));
 String defaultLocale = wiseProperties.getProperty("defaultLocale");
 request.setAttribute("defaultLocale", defaultLocale);
+String wiseBaseURL = wiseProperties.getProperty("wiseBaseURL");
+request.setAttribute("wiseBaseURL", wiseBaseURL);
 %>
 
 <!-- $Id$ -->
@@ -41,4 +43,5 @@ request.setAttribute("defaultLocale", defaultLocale);
 <c:set var="sessionLocale" value="${sessionScope['org.springframework.web.servlet.i18n.SessionLocaleResolver.LOCALE']}"/>
 <c:set var="locale" value="${ empty sessionLocale ? defaultLocale : sessionLocale }" />
 <c:set var="textDirection" value="${'iw' == locale || 'ar' == locale ? 'rtl' : 'ltr'}" />
+<c:set var="wiseBaseURL" value="${wiseBaseURL}"/>
 <c:set var="contextPath" value="${pageContext.request.contextPath}"/>

--- a/src/main/webapp/portal/translate/index.jsp
+++ b/src/main/webapp/portal/translate/index.jsp
@@ -120,7 +120,7 @@
     <c:when test="${!empty param.userLocale && empty param.projectType}">
         <!-- case when user has chosen a locale but not the project to translate. Show them the translatable projects -->
         <!DOCTYPE html>
-        <html dir="${textDirection}">
+        <html x-dir="${textDirection}"> <%-- The page always ltr --%>
         <head>
             <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
             <meta http-equiv="X-UA-Compatible" content="chrome=1" />
@@ -435,6 +435,12 @@
                 .cell_key {
                     word-wrap:break-word;
                     width:200px;
+                }
+                textarea {
+                  resize: vertical;
+                }
+                .foreignText.ar, .foreignText.iw {
+                  direction: rtl;
                 }
             </style>
         </head>

--- a/src/main/webapp/portal/translate/js/common.js
+++ b/src/main/webapp/portal/translate/js/common.js
@@ -301,6 +301,7 @@ View.prototype.retrieveLocale = function(locale,projectType) {
 /*
  * before user navigates away from the page or refreshes it, check to see if
  * user needs to save changes or not
+ * return nothing to continue without the message.
  */
 window.onbeforeunload = function() {
   if (isDirty) {
@@ -310,7 +311,7 @@ window.onbeforeunload = function() {
      */
     return false;
   } else {
-    return true;
+    return;
   }
 };
 

--- a/src/main/webapp/portal/translate/js/translateJSON.js
+++ b/src/main/webapp/portal/translate/js/translateJSON.js
@@ -31,9 +31,9 @@ function buildTable5() {
 			var value = View.prototype.i18n[View.prototype.i18n.defaultLocale][key].replace(/[\n]/g, "\\n");
 			translationTable += "<tr class='translationRow'>\n<td class='cell_key'>"+key+"</td>\n<td><textarea style='border:none;width:100%;height:100%' class='englishText' readonly='true'>"+value+"</textarea></td>\n";
 			if (View.prototype.i18n[currentLanguage][key]) {
-				translationTable += "<td class='cell_currentLanguage'><textarea style='height:100%;width:100%' class='foreignText' id='"+key+"'>"+View.prototype.i18n[currentLanguage][key].replace(/[\n]/g, "\\n")+"</textarea></td>\n";
+				translationTable += "<td class='cell_currentLanguage'><textarea style='height:100%;width:100%' class='foreignText "+currentLanguage+"' id='"+key+"'>"+View.prototype.i18n[currentLanguage][key].replace(/[\n]/g, "\\n")+"</textarea></td>\n";
 			} else {
-				translationTable += "<td class='cell_currentLanguage'><textarea style='height:100%;width:100%' class='foreignText' id='"+key+"'></textarea></td>\n";
+				translationTable += "<td class='cell_currentLanguage'><textarea style='height:100%;width:100%' class='foreignText "+currentLanguage+"' id='"+key+"'></textarea></td>\n";
 			}
 			translationTable += "</tr>\n\n";                      
 		}
@@ -80,9 +80,9 @@ function buildTable_JSON() {
 			var value = obj.value.replace(/[\n]/g, "\\n");
 			translationTable += "<tr class='translationRow'>\n<td class='cell_key'>"+key+"</td>\n<td>"+obj.description+"</td>\n<td><textarea style='border:none;width:100%;height:100%' class='englishText' readonly='true'>"+value+"</textarea></td>\n";
 			if (View.prototype.i18n[currentLanguage][key]) {
-				translationTable += "<td class='cell_currentLanguage'><textarea style='height:100%;width:100%' class='foreignText' id='"+key+"'>"+View.prototype.i18n[currentLanguage][key].value.replace(/[\n]/g, "\\n")+"</textarea></td>\n";
+				translationTable += "<td class='cell_currentLanguage'><textarea style='height:100%;width:100%' class='foreignText "+currentLanguage+"' id='"+key+"'>"+View.prototype.i18n[currentLanguage][key].value.replace(/[\n]/g, "\\n")+"</textarea></td>\n";
 			} else {
-				translationTable += "<td class='cell_currentLanguage'><textarea style='height:100%;width:100%' class='foreignText' id='"+key+"'></textarea></td>\n";
+				translationTable += "<td class='cell_currentLanguage'><textarea style='height:100%;width:100%' class='foreignText "+currentLanguage+"' id='"+key+"'></textarea></td>\n";
 			}
 			translationTable += "</tr>\n\n";                      
 		}


### PR DESCRIPTION
Add missing rtl-stylesheet to pages.
Add pageWrapper to fix layout for some missing pages
hide horizontal scrollbar for pages without header
Fix translate UI layout for rtl foreignText.
Fix the "Leave Site" alert message box when nothing is changed.
Pass wiseBaseURL to request, because some pages like statistics was not able to get the correct wiseBaseURL when configured.